### PR TITLE
install.ps1 remplacé par install.bat et install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 public
 
 zola.exe
+zola

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 Utilise [Zola](https://www.getzola.org/).
 
 * [Procédure d'installation](https://www.getzola.org/documentation/getting-started/installation/)
-* Procédure d'installation sur les PC à la HEG:
-    * Démarrer powershell
-    * Exécuter `.\install.ps1`
+* Procédure d'installation sur Windows:
+    * Démarrer cmd.exe (invite de commande)
+    * Exécuter `.\install.bat`
+* Procédure d'installation sur MacOS et Linux:
+    * Exécuter `.\install.sh`
 
 ## Structure
 
@@ -41,7 +43,7 @@ Pour faire simple, il suffit de reprendre les exemples existants.
 
 ## Démarrer le serveur
 
-`.\zola serve`
+`zola serve`
 
 Puis ouvrir la page <http://127.0.0.1:1111> comme indiqué.
 
@@ -51,7 +53,7 @@ Note: en dehors des PC à la HEG il suffit d'écrire `zola serve` sans `.\`.
 
 ## Compiler le site
 
-`.\zola build`
+`zola build`
 
 Tout le contenu est dans le répertoire `public`
 

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,33 @@
+@echo off
+setlocal
+
+:: Set the URL and output file
+set "URL=https://github.com/getzola/zola/releases/download/v0.19.2/zola-v0.19.2-x86_64-pc-windows-msvc.zip"
+set "OUTPUT=zola.zip"
+
+:: Download the file using curl
+echo Downloading Zola...
+curl -L -o "%OUTPUT%" "%URL%"
+if errorlevel 1 (
+    echo Failed to download Zola.
+    exit /b 1
+)
+
+:: Extract the ZIP file
+echo Extracting Zola...
+powershell -Command "Expand-Archive -Path '%OUTPUT%' -DestinationPath '.' -Force"
+if errorlevel 1 (
+    echo Failed to extract Zola.
+    exit /b 1
+)
+
+:: Remove the ZIP file
+echo Cleaning up...
+del "%OUTPUT%"
+if errorlevel 1 (
+    echo Failed to remove the ZIP file.
+    exit /b 1
+)
+
+echo Zola installation completed successfully.
+exit /b 0

--- a/install.ps1
+++ b/install.ps1
@@ -1,3 +1,0 @@
-Invoke-WebRequest -Uri "https://github.com/getzola/zola/releases/download/v0.19.2/zola-v0.19.2-x86_64-pc-windows-msvc.zip" -OutFile "zola.zip"
-Expand-Archive -Path "zola.zip" -DestinationPath "." -Force
-Remove-Item "zola.zip"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Detect OS
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+if [ "$OS" == "Darwin" ]; then
+    # macOS
+    if [ "$ARCH" == "arm64" ]; then
+        URL="https://github.com/getzola/zola/releases/download/v0.19.2/zola-v0.19.2-aarch64-apple-darwin.tar.gz"
+    elif [ "$ARCH" == "x86_64" ]; then
+        URL="https://github.com/getzola/zola/releases/download/v0.19.2/zola-v0.19.2-x86_64-apple-darwin.tar.gz"
+    else
+        echo "Unsupported architecture for macOS: $ARCH"
+        exit 1
+    fi
+elif [ "$OS" == "Linux" ]; then
+    # Linux
+    if [ "$ARCH" == "x86_64" ]; then
+        URL="https://github.com/getzola/zola/releases/download/v0.19.2/zola-v0.19.2-x86_64-unknown-linux-gnu.tar.gz"
+    else
+        echo "Unsupported architecture for Linux: $ARCH"
+        exit 1
+    fi
+else
+    echo "Unsupported operating system: $OS"
+    exit 1
+fi
+
+# Set output file and destination directory
+OUTPUT="zola.tar.gz"
+DESTINATION="."
+
+# Download the appropriate file
+echo "Downloading Zola for OS: $OS, Architecture: $ARCH"
+curl -L -o "$OUTPUT" "$URL"
+
+# Extract the tar.gz file
+echo "Extracting Zola..."
+mkdir -p "$DESTINATION"
+tar -xzf "$OUTPUT" -C "$DESTINATION"
+
+# Remove the tar.gz file
+echo "Cleaning up..."
+rm -f "$OUTPUT"


### PR DESCRIPTION
Sous Windows, install.ps1 pose un problème de permission (script non signé).
Avec l'invite de commande (install.bat) cela fonctionne sans signature.
Il y a aussi un install.sh qui fonctionne sur MacOS et Linux.